### PR TITLE
Dynamic node environments and Add remote shell task

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,39 +20,46 @@ To use just import some or all of the tasks into your fabric file. Or
 create a blank fabfile.py with the following contents.
 
     #! /usr/bin/env python
-    from cloth.tasks import *
+    from cloth import tasks as ec2
+
+    ec2.set_node_envs({
+        'preview': '^preview-',
+        'development': '^website-dev',
+        'production': '^website-prod'
+    })
 
 This will give you a good few commands.
 
     ⚡ fab -l
     Available commands:
 
-      all         All nodes
-      free        Show memory stats
-      list        List EC2 name and public and private ip address
-      nodes       Select nodes based on a regular expression
-      preview     Preview nodes
-      production  Production nodes
-      updates     Show package counts needing updates
-      upgrade     Upgrade packages with apt-get
-      uptime      Show uptime and load
+      ec2.all         All nodes
+      ec2.free        Show memory stats
+      ec2.list        List EC2 name and public and private ip address
+      ec2.nodes       Select nodes based on a regular expression
+      ec2.development Development nodes
+      ec2.staging     Staging nodes
+      ec2.production  Production nodes
+      ec2.updates     Show package counts needing updates
+      ec2.upgrade     Upgrade packages with apt-get
+      ec2.uptime      Show uptime and load
 
 Of most interest should be the 'all' and 'nodes' tasks. These allow you
 to load EC2 instances for further command running.
 
-    ⚡ fab all list
+    ⚡ fab ec2.all ec2.list
 
 The above should list all of your EC2 instances including the name and
 public and private ip addresses.
 
-    ⚡ fab nodes:"^production.*" list
+    ⚡ fab ec2.nodes:"^production.*" ec2.list
 
 The above should list all of your EC2 instances that start with
 'production'. This takes a regex as the argument so you can get whatever
 instances you like.
 
 
-    ⚡ fab all uptime
+    ⚡ fab ec2.all ec2.uptime
 
 As an example of running a command on a set of EC2 instances try the
 above. This should show the uptime and load averages for all your EC2
@@ -88,7 +95,7 @@ I could write a task like so:
 
 The run that task with:
 
-    ⚡ fab all passenger
+    ⚡ fab ec2.all passenger
 
 That task would only be run on the three backend instances.
 

--- a/src/cloth/tasks.py
+++ b/src/cloth/tasks.py
@@ -1,14 +1,32 @@
 #! /usr/bin/env python
-
+import sys
+from functools import partial
 from collections import defaultdict
 
-from fabric.api import run, env, sudo, task, runs_once, roles
+from fabric.api import run, env, sudo, task, runs_once
 
 from cloth.utils import instances, use
 
 
+module = sys.modules[__name__]
 env.nodes = []
 env.roledefs = defaultdict(list)
+
+NODE_ENVS = {
+    'preview': '^preview-',
+    'production': '^production-'
+}
+
+
+def set_node_envs(node_envs=NODE_ENVS):
+    for node_env in node_envs:
+        def _env_nodes(k):
+            nodes(node_envs.get(k))
+
+        ptask = partial(_env_nodes, node_env)
+        ptask.__doc__ = "{0} nodes".format(node_env.capitalize())
+
+        setattr(module, node_env, task(name=node_env)(ptask))
 
 
 @task
@@ -17,17 +35,6 @@ def all():
     for node in instances():
         use(node)
 
-@task
-def preview():
-    "Preview nodes"
-    for node in instances('^preview-'):
-        use(node)
-
-@task
-def production():
-    "Production nodes"
-    for node in instances('^production-'):
-        use(node)
 
 @task
 def nodes(exp):
@@ -35,31 +42,36 @@ def nodes(exp):
     for node in instances(exp):
         use(node)
 
+
 @task
 @runs_once
 def list():
     "List EC2 name and public and private ip address"
     for node in env.nodes:
-        print "%s (%s, %s)" % (node.tags["Name"], node.ip_address,
-            node.private_ip_address)
+        print "{0} ({1}, {2})".format(node.tags["Name"],
+                                      node.ip_address,
+                                      node.private_ip_address)
+
 
 @task
 def uptime():
     "Show uptime and load"
     run('uptime')
 
+
 @task
 def free():
     "Show memory stats"
     run('free')
+
 
 @task
 def updates():
     "Show package counts needing updates"
     run("cat /var/lib/update-notifier/updates-available")
 
+
 @task
 def upgrade():
     "Upgrade packages with apt-get"
     sudo("apt-get update; apt-get upgrade -y")
-

--- a/src/cloth/tasks.py
+++ b/src/cloth/tasks.py
@@ -3,9 +3,9 @@ import sys
 from functools import partial
 from collections import defaultdict
 
-from fabric.api import run, env, sudo, task, runs_once
+from fabric.api import run, env, sudo, task, runs_once, local
 
-from cloth.utils import instances, use
+from cloth.utils import instances, use, ip
 
 
 module = sys.modules[__name__]
@@ -75,3 +75,12 @@ def updates():
 def upgrade():
     "Upgrade packages with apt-get"
     sudo("apt-get update; apt-get upgrade -y")
+
+
+@task
+@runs_once
+def shell():
+    "Instance remote interactive shell"
+    node = next(iter(env.nodes), None)
+    if node:
+        local('ssh {0}@{1}'.format(env.user, ip(node)))


### PR DESCRIPTION
With set_node_envs we add dynamic tasks for those environments using the specified reg exp.

Also, imho i think is always better to put cloth tasks inside a specific context, so i updated README accordingly.
